### PR TITLE
don't require openssl on illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.6.1-rc1-il-6
+VERSION=0.6.1-rc1-il-7
 
 ########################################################################
 # The following variables can be overwritten from the command line

--- a/smatch_mtag.c
+++ b/smatch_mtag.c
@@ -46,7 +46,11 @@
 #include "smatch_slist.h"
 #include "smatch_extra.h"
 
+#ifdef __sun
+#include <md5.h>
+#else
 #include <openssl/md5.h>
+#endif
 
 static int my_id;
 
@@ -54,13 +58,18 @@ mtag_t str_to_mtag(const char *str)
 {
 	unsigned char c[MD5_DIGEST_LENGTH];
 	unsigned long long *tag = (unsigned long long *)&c;
-	MD5_CTX mdContext;
 	int len;
 
 	len = strlen(str);
+
+#ifdef __sun
+	md5_calc(c, str, len);
+#else
+	MD5_CTX mdContext;
 	MD5_Init(&mdContext);
 	MD5_Update(&mdContext, str, len);
 	MD5_Final(c, &mdContext);
+#endif
 
 	*tag &= ~MTAG_ALIAS_BIT;
 	*tag &= ~MTAG_OFFSET_MASK;


### PR DESCRIPTION
Pull in fix for:

13985 Support building with OpenSSL 3.0

adjusted to not break Linux build.

Signed-off-by: John Levon <levon@movementarian.org>